### PR TITLE
Update FLAMEGPU2 Wheel to for CUDA 11.2

### DIFF
--- a/FLAME_GPU_2_python_tutorial.ipynb
+++ b/FLAME_GPU_2_python_tutorial.ipynb
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "!{sys.executable} -m pip install -I https://github.com/FLAMEGPU/FLAMEGPU2/releases/download/v2.0.0-alpha.1/pyflamegpu-2.0.0a1+cuda110-cp36-cp36m-linux_x86_64.whl\n",
+    "!{sys.executable} -m pip install -I https://github.com/FLAMEGPU/FLAMEGPU2/releases/download/v2.0.0-alpha.1/pyflamegpu-2.0.0a1+cuda112-cp37-cp37m-linux_x86_64.whl\n",
     "\n",
     "import os\n",
     "\n",


### PR DESCRIPTION
This will require running through the tutorial to check for breaking changes to the API too. I had a quick click through the default stuff and it got as far as generating the graph fine. I didn't try adding the any of the solutions though.