### PR TITLE
Update Google Collab page to use RC0 wheel

### DIFF
--- a/FLAME_GPU_2_python_tutorial.ipynb
+++ b/FLAME_GPU_2_python_tutorial.ipynb
@@ -50,12 +50,9 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "!{sys.executable} -m pip install -I https://github.com/FLAMEGPU/FLAMEGPU2/releases/download/v2.0.0-alpha.1/pyflamegpu-2.0.0a1+cuda112-cp38-cp38-linux_x86_64.whl\n",
-    "\n",
-    "import os\n",
+    "!{sys.executable} -m pip install -I https://github.com/FLAMEGPU/FLAMEGPU2/releases/download/v2.0.0-rc/pyflamegpu-2.0.0rc0+cuda112-cp38-cp38-linux_x86_64.whl\n",
     "\n",
     "# Import pyflamegpu and some other libraries we will use in the tutorial\n",
-    "sys.path.append(os.path.expanduser('~') + \"/.local/lib/python3.6/site-packages\")\n",
     "import pyflamegpu\n",
     "import sys, random, math\n",
     "import matplotlib.pyplot as plt\n"
@@ -969,7 +966,7 @@
     "}\n",
     "\"\"\"\n",
     "\n",
-    "class population_tracker(pyflamegpu.HostFunctionCallback):\n",
+    "class population_tracker(pyflamegpu.HostFunction):\n",
     "    def __init__(self, has_grass):\n",
     "        super().__init__();  # Mandatory if we are defining __init__ ourselves\n",
     "        # Local, so value is maintained between calls to calculate_convergence::run\n",
@@ -1012,7 +1009,7 @@
    "source": [
     "# Keeping Track of Model Outputs\n",
     "\n",
-    "It is possible for FLAME GPU 2 to log the variables of each agent at every time step. This can be useful for post processing of simulation data but is usually more information than is required. For the predator prey model we are interested only in the population counts and as such we can use FLAME GPUs init, step and exit functions to run host code for logging or tracking information about the state of the model. Init functions are executed once at the start of a simulation, [step functions](https://docs.flamegpu.com/guide/3-behaviour-definition/6-host-functions.html) are run after each simulation step and exit functions are run at the end of the simulation. In this case, we have used FLAME GPU 2's `HostFunctionCallback` to track the populations at each step and plot them. This is shown at the end of the previous code segment."
+    "It is possible for FLAME GPU 2 to log the variables of each agent at every time step. This can be useful for post processing of simulation data but is usually more information than is required. For the predator prey model we are interested only in the population counts and as such we can use FLAME GPUs init, step and exit functions to run host code for logging or tracking information about the state of the model. Init functions are executed once at the start of a simulation, [step functions](https://docs.flamegpu.com/guide/3-behaviour-definition/6-host-functions.html) are run after each simulation step and exit functions are run at the end of the simulation. In this case, we have used FLAME GPU 2's `HostFunction` to track the populations at each step and plot them. This is shown at the end of the previous code segment."
    ]
   },
   {
@@ -1108,7 +1105,7 @@
     "\n",
     "    # Set up a population tracker for logging/plotting\n",
     "    pop_tracker = population_tracker(num_grass > 0)\n",
-    "    model.addStepFunctionCallback(pop_tracker.__disown__())\n",
+    "    model.addStepFunction(pop_tracker)\n",
     "    \n",
     "    \"\"\"\n",
     "      Create Model Runner\n",

--- a/FLAME_GPU_2_python_tutorial.ipynb
+++ b/FLAME_GPU_2_python_tutorial.ipynb
@@ -49,8 +49,10 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "!{sys.executable} -m pip install -I https://github.com/FLAMEGPU/FLAMEGPU2/releases/download/v2.0.0-rc/pyflamegpu-2.0.0rc0+cuda112-cp38-cp38-linux_x86_64.whl\n",
+    "import importlib.util\n",
+    "if importlib.util.find_spec('pyflamegpu') is None:\n",
+    "    import sys\n",
+    "    !{sys.executable} -m pip install -I https://github.com/FLAMEGPU/FLAMEGPU2/releases/download/v2.0.0-rc/pyflamegpu-2.0.0rc0+cuda112-cp38-cp38-linux_x86_64.whl # type: ignore\n",
     "\n",
     "# Import pyflamegpu and some other libraries we will use in the tutorial\n",
     "import pyflamegpu\n",

--- a/FLAME_GPU_2_python_tutorial.ipynb
+++ b/FLAME_GPU_2_python_tutorial.ipynb
@@ -446,9 +446,6 @@
    },
    "outputs": [],
    "source": [
-    "# Change to false if pyflamegpu has not been built with visualisation support\n",
-    "VISUALISATION = False\n",
-    "\n",
     "\"\"\"\n",
     "  outputdata agent function for Boid agents, which outputs publicly visible properties to a message list\n",
     "\"\"\"\n",


### PR DESCRIPTION
Only changes are the wheel, and removal of `Callback` from two places related to host functions. I manually applied the changes and solutions in the normal collab to test them and updated this in parallel.

Also tested it works without the site-packages update.

It now executes the model much faster, with the improved RTC times.

- [x] I guess these changes should be applied to `master` too?
- [x] Address https://github.com/FLAMEGPU/FLAMEGPU2-tutorial-python/issues/16 too?

Closes #18