### PR TITLE
Install pyflamegpu from the whl.flamegpu.com.

### DIFF
--- a/FLAME_GPU_2_python_tutorial.ipynb
+++ b/FLAME_GPU_2_python_tutorial.ipynb
@@ -52,7 +52,7 @@
     "import importlib.util\n",
     "if importlib.util.find_spec('pyflamegpu') is None:\n",
     "    import sys\n",
-    "    !{sys.executable} -m pip install -I https://github.com/FLAMEGPU/FLAMEGPU2/releases/download/v2.0.0-rc/pyflamegpu-2.0.0rc0+cuda112-cp38-cp38-linux_x86_64.whl # type: ignore\n",
+    "    !{sys.executable} -m pip install --extra-index-url https://whl.flamegpu.com/whl/cuda112/ pyflamegpu==2.0.0rc0 # type: ignore\n",
     "\n",
     "# Import pyflamegpu and some other libraries we will use in the tutorial\n",
     "import pyflamegpu\n",


### PR DESCRIPTION
We must use a specific url as we need a specific cuda and a non vis wheel, so cannoy just use latest.

Plus to avoid breakage on a new version, lets pin that too (2.0.0rc0)

Must use --extra-index-url (or --find-links), as astpretty is not installed on collab by default. 

![image](https://github.com/FLAMEGPU/FLAMEGPU2-tutorial-python/assets/628937/e7da4172-dad3-45d5-8ebc-8f77d24c5bdc)

This will mean that if collab change the python version, as long as it is a version in our wheelhouse for the pinned release we don't need to update it. 

If the CUDA version changes to 12.x, we will need to update it. Otherwise 11.2 should be OK due to CUDA 11.2+ abi stability.