### PR TITLE
Install pyflamegpu from the whl.flamegpu.com wheelhouse

### DIFF
--- a/FLAME_GPU_2_python_tutorial.ipynb
+++ b/FLAME_GPU_2_python_tutorial.ipynb
@@ -52,7 +52,7 @@
     "import importlib.util\n",
     "if importlib.util.find_spec('pyflamegpu') is None:\n",
     "    import sys\n",
-    "    !{sys.executable} -m pip install -I https://github.com/FLAMEGPU/FLAMEGPU2/releases/download/v2.0.0-rc/pyflamegpu-2.0.0rc0+cuda112-cp310-cp310-linux_x86_64.whl # type: ignore\n",
+    "    !{sys.executable} -m pip install --extra-index-url https://whl.flamegpu.com/whl/cuda112/ pyflamegpu==2.0.0rc0 # type: ignore\n",
     "\n",
     "# Import pyflamegpu and some other libraries we will use in the tutorial\n",
     "import pyflamegpu\n",


### PR DESCRIPTION
Applies the same change as #25 to the google-collab version of the tutorial.

URL for testing on collab: 

https://colab.research.google.com/github/FLAMEGPU/FLAMEGPU2-tutorial-python/blob/google-colab-wheelhouse/FLAME_GPU_2_python_tutorial.ipynb